### PR TITLE
add ldap contrib package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm files
+.idea

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -1,0 +1,139 @@
+# Geonode auth via LDAP
+
+This package provides utilities for using LDAP as an authentication and 
+authorization backend for geonode.
+
+The [django_auth_ldap][1] package is a very capable way to add LDAP integration 
+with django projects. It provides a lot of flexibility in mapping LDAP users to 
+geonode users and is able to manage user authentication.
+
+However, in order to provide full support for mapping LDAP groups with 
+geonode's and enforce group permissions on resources, a custom geonode 
+authentication backend  is required. This contrib package provides such a 
+backend, based on django_auth_ldap.
+
+
+## Installation
+
+
+Installing this contrib package is a matter of:
+
+1. [Installing geonode](http://geonode.org/#install)
+2. Installing system LDAP libraries (development packages needed)
+3. Cloning this repository locally
+4. Change to the `ldap` directory and install this contrib package
+
+```sh
+# 1. install geonode (not shwn here for brevity)
+# 2. install systemwide LDAP libraries
+sudo apt install \
+    libldap2-dev \
+    libsasl2-dev
+    
+# 3. get geonode/contribs code
+git clone https://github.com/GeoNode/geonode-contribs.git
+
+# 4. install geonode ldap contrib package
+cd geonode-contribs/ldap
+pip install .
+```
+
+
+## Configuration
+
+1. Add `geonode_ldap.backend.GeonodeLdapBackend` as an additional auth
+   backend (see example configuration below).
+
+   You may use additional auth backends, the django authentication framework
+   tries them all according to the order listed in the settings. This means that
+   geonode can be setup in such a way as to permit internal organization users
+   to login with their LDAP credentials, while at the same time allowing for
+   casual users to use their facebook login (as long as you enable facebook
+   social auth provider).
+
+   Note that django's `django.contrib.auth.backends.ModelBackend` must also
+   be used in order to provide full geonode integration with LDAP.
+
+2. Set some additional configuration values. Some of these variables are
+   prefixed with `AUTH_LDAP` (these are used directly by `django_auth_ldap`)
+   while others are prefixed with `GEONODE_LDAP` (these are used by
+   `geonode_ldap`). The geonode custom variables are:
+
+   * `GEONODE_LDAP_GROUP_PROFILE_FILTERSTR` - This is an LDAP search fragment
+     with the filter that allows querying for existing groups. See example below
+
+   * `GEONODE_LDAP_GROUP_NAME_ATTRIBUTE` - This is the name of the LDAP
+     attribute that will be used for deriving the geonode group name. If not
+     specified it will default to `cn`, which means that the LDAP object's
+     `common name` will be used for generating the name of the geonode group
+
+
+Example configuration:
+
+```python
+# add these import lines to the top of your geonode settings file
+from django_auth_ldap import config as ldap_config
+from geonode_ldap.config import GeonodeNestedGroupOfNamesType
+import ldap
+
+# add both standard ModelBackend auth and geonode.contrib.ldap auth
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'geonode_ldap.backend.GeonodeLdapBackend',
+)
+
+# django_auth_ldap configuration
+AUTH_LDAP_SERVER_URI = 'ldap://example.com'
+AUTH_LDAP_BIND_DN = 'cn=admin,dc=example,dc=com'
+AUTH_LDAP_BIND_PASSWORD = 'something-secret'
+AUTH_LDAP_USER_SEARCH = ldap_config.LDAPSearch(
+    'ou=people,dc=example,dc=com',
+    ldap.SCOPE_SUBTREE,
+    '(cn=%(user)s)'
+)
+AUTH_LDAP_GROUP_SEARCH = ldap_config.LDAPSearch(
+    'ou=groups,dc=example,dc=com',
+    ldap.SCOPE_SUBTREE,
+)
+AUTH_LDAP_GROUP_TYPE = GeonodeNestedGroupOfNamesType()
+AUTH_LDAP_USER_ATTR_MAP = {
+    'first_name': 'cn',
+    'last_name': 'sn'
+}
+AUTH_LDAP_FIND_GROUP_PERMS = True
+AUTH_LDAP_MIRROR_GROUPS_EXCEPT = [
+    'test_group'
+]
+
+# geonode.contrib.ldap configuration
+GEONODE_LDAP_GROUP_NAME_ATTRIBUTE = 'cn'
+GEONODE_LDAP_GROUP_PROFILE_FILTERSTR = '(ou=research group)'
+```
+
+The configuration seen in the example above will allow LDAP users to login to
+geonode with their LDAP credentials.
+
+On first login, a geonode user is created from the LDAP user and its LDAP
+attributes `cn` and `sn` are used to populate the geonode user's
+`first_name` and `last_name` profile fields.
+
+Any groups that the user is a member of in LDAP (under the
+`ou=groups,dc=example,dc=com` search base and with an
+`(ou=research group)` attribute) will be mapped to the corresponding
+geonode groups, even creating these groups in geonode in case they do not
+exist yet. The geonode user is also made a member of these geonode groups.
+
+Upon each login, the user's geonode group memberships are re-evaluated
+according to the information extracted from LDAP. The
+`AUTH_LDAP_MIRROR_GROUPS_EXCEPT` setting can be used to specify groups
+whose memberships will not be re-evaluated.
+
+You may also manually generate the geonode groups in advance, before users
+login. In this case, when a user logs in and the mapped LDAP group already
+exists, the user is merely added to the geonode group
+
+Be sure to check out [django_auth_ldap][1] for more information on the various
+configuration options.
+
+
+[1]: https://django-auth-ldap.readthedocs.io/en/latest/

--- a/ldap/geonode_ldap/backend.py
+++ b/ldap/geonode_ldap/backend.py
@@ -1,0 +1,273 @@
+"""Custom auth backend that harmonizes ``django_auth_ldap`` and geonode
+
+This module provides an authentication backend that can be used together with
+``django_auth_ldap`` in order to provide group permissions based on LDAP groups
+
+If you just want to connect with an LDAP server for creating users and managing
+authentication (login and logout), then you don't need this and
+``django_auth_ldap`` is enough, provided that you set the correct variables in
+the geonode ``settings.py`` file.
+
+If you want to extract group information from LDAP and map it to geonode
+permissions you will need to use the auth backend supplied in this module
+(or a similar solution).
+
+
+Why this module exists
+----------------------
+
+``django_auth_ldap`` offers a very flexible and complete way to map groups
+to LDAP and use the permissions defined in django - however, geonode has a
+non-standard way of managing its groups and users, hence the need for this
+custom auth backend class.
+
+In a nutshell, geonode wants to manage group memberships using the
+``django.contrib.auth.models.Group`` class (i.e. the usual django way) **and**
+also with the ``geonode.groups.models.GroupMember`` class.
+
+"""
+
+import logging
+import pprint
+
+from django.db import transaction
+from django_auth_ldap import backend
+from geonode.groups.models import (
+    GroupProfile,
+    GroupMember,
+)
+import ldap
+
+from . import utils
+
+logger = logging.getLogger(__name__)
+
+
+class GeonodeLdapBackend(backend.LDAPBackend):
+
+    def authenticate_ldap_user(self, ldap_user, password):
+        """Returns an authenticated Django user or None.
+
+        Authenticates against the LDAP directory and returns the corresponding
+        User object if successful. Returns None on failure.
+
+        This method is called by this backend's ``authenticate()`` method, which
+        is what django actually uses.
+
+        This method is only reimplemented because we ultimately want
+        django_auth_ldap to create instances of
+        ``geonode.people.models.GroupProfile`` instead of vanilla django groups.
+
+        Since the creation of groups is done deeper in
+        ``django_auth_ldap.backend._LDAPUser._mirror_groups()``, for a lack of
+        a better place to hook into, we need to start reimplementing at this
+        level in order to be able to modify it.
+
+        This current approach is certainly a hack. Unfortunately, as long as
+        geonode holds group memberships in both
+        ``django.contrib.auth.models.Group`` and
+        ``geonode.groups.models.GroupMember`` there does not seem to be a clean
+        way to map LDAP groups to geonode groups and still be able to use
+        geonode's permissions.
+
+        This method is reimplemented in order to provide support for custom
+        management of geonode groups. The intent is to reuse code from
+        ``django_auth_ldap`` as much as possible. As such, the _LDAPUser class
+        is being re-used too. In django_auth_ldap this is the method that starts
+        the user and group verification. We notoriously replace the following
+        _LDAPUser methods with custom ones:
+
+        * ``_LDAPUser._get_or_create_user()`` - we provide
+          ``CustomLdapBackend._get_or_create_user()``, which does the same job
+          but takes ``ldap_user`` as an input paremeter instead
+
+        * ``LDAPUser._mirror_groups()`` - we provide
+          ``CustomLdapBackend.mirror_groups()`` instead, which takes
+          ``ldap_user`` as an input paremeter instead and also has custom logic
+
+        """
+
+        user = None
+
+        try:
+            ldap_user._authenticate_user_dn(password)
+            ldap_user._check_requirements()
+            self._get_or_create_user(ldap_user)
+
+            user = ldap_user._user
+        except ldap_user.AuthenticationFailed as e:
+            logger.debug(
+                "Authentication failed for {}: {}".format(
+                    ldap_user._username, e)
+            )
+        except ldap.LDAPError as e:
+            results = backend.ldap_error.send(
+                ldap_user.backend.__class__,
+                context='authenticate',
+                user=ldap_user._user,
+                exception=e
+            )
+            if len(results) == 0:
+                logger.warning(
+                    "Caught LDAPError while authenticating {}: {}".format(
+                        ldap_user._username, pprint.pformat(e)
+                    )
+                )
+        except Exception as e:
+            logger.warning(
+                "{} while authenticating {}".format(e, ldap_user._username)
+            )
+            raise
+
+        return user
+
+    def _get_or_create_user(self, ldap_user, force_populate=False):
+        """Reimplemented based on django_auth_ldap _LDAPUser.get_or_create_user
+
+        Loads the User model object from the database or creates it if it
+        doesn't exist. Also populates the fields, subject to
+        AUTH_LDAP_ALWAYS_UPDATE_USER.
+
+        """
+
+        save_user = False
+
+        username = self.ldap_to_django_username(ldap_user._username)
+
+        ldap_user._user, built = self.get_or_build_user(username, ldap_user)
+        ldap_user._user.ldap_user = ldap_user
+        ldap_user._user.ldap_username = ldap_user._username
+
+        should_populate = (
+                force_populate or self.settings.ALWAYS_UPDATE_USER or built)
+
+        if built:
+            ldap_user._user.set_unusable_password()
+            save_user = True
+
+        if should_populate:
+            ldap_user._populate_user()
+            save_user = True
+
+            # Give the client a chance to finish populating the user just
+            # before saving.
+            backend.populate_user.send(
+                self.__class__,
+                user=ldap_user._user,
+                ldap_user=ldap_user
+            )
+
+        if save_user:
+            ldap_user._user.save()
+
+        # This has to wait until we're sure the user has a pk.
+        if self.settings.MIRROR_GROUPS or self.settings.MIRROR_GROUPS_EXCEPT:
+            ldap_user._normalize_mirror_settings()
+            self._mirror_groups(ldap_user)
+
+    def _mirror_groups(self, ldap_user):
+        """Reimplemented in order to generate ``people.GroupProfile`` instances
+
+        Mirrors the user's LDAP groups in the Django database and updates the
+        user's membership.
+
+        """
+
+        user = ldap_user._user
+        slug_map = utils.get_ldap_groups_map(user)
+        profile_slugs_set = frozenset(slug_map.keys())
+        current_group_profile_slugs = frozenset(
+            user.groups.values_list(
+                "groupprofile__slug",
+                flat=True
+            ).filter(groupprofile__slug__isnull=False)
+        )
+        MIRROR_GROUPS_EXCEPT = self.settings.MIRROR_GROUPS_EXCEPT
+        MIRROR_GROUPS = self.settings.MIRROR_GROUPS
+
+        if isinstance(MIRROR_GROUPS_EXCEPT, (set, frozenset)):
+            profile_slugs_set = (
+                    (profile_slugs_set - MIRROR_GROUPS_EXCEPT) |
+                    (current_group_profile_slugs & MIRROR_GROUPS_EXCEPT)
+            )
+        elif isinstance(MIRROR_GROUPS, (set, frozenset)):
+            profile_slugs_set = (
+                    (profile_slugs_set & MIRROR_GROUPS) |
+                    (current_group_profile_slugs - MIRROR_GROUPS)
+            )
+        if profile_slugs_set != current_group_profile_slugs:
+            existing_group_profiles = list(GroupProfile.objects.filter(
+                slug__in=profile_slugs_set).iterator())
+            existing_group_profile_slugs = frozenset(
+                profile.slug for profile in existing_group_profiles)
+            new_group_profiles = []
+            for profile_slug in profile_slugs_set:
+                if profile_slug not in existing_group_profile_slugs:
+                    profile_names = slug_map.get(profile_slug, {})
+                    group_profile, created = GroupProfile.objects.get_or_create(
+                        title=profile_names.get("sanitized", profile_slug),
+                        slug=profile_slug,
+                        defaults={
+                            "description": profile_names.get(
+                                "original", profile_slug)
+                        }
+                    )
+                    new_group_profiles.append(group_profile)
+            replace_user_groups(
+                user,
+                existing_group_profiles + new_group_profiles
+            )
+
+
+@transaction.atomic
+def replace_user_groups(user, group_profiles):
+    """Set user group memberships based on the input group_profiles
+
+    This function operates on both types of groups that currently exist in
+    geonode:
+
+    - regular ``django.contrib.auth.models.Group`` groups which are needed for
+      checking permissions
+
+    - geonode's custom ``geonode.groups.models.GroupProfile`` which are used as
+      profiles but also store membership information
+
+    All user memberships related with the ``GroupProfile`` class (which are
+    being mediated by the ``GroupMember`` model) are first deleted. The
+    companion ``Group`` memberships are also deleted.
+
+    Then new memberships are created according to the profiles specified in the
+    ``group_profiles`` parameter and the corresponding ``Group`` memberships
+    are also created.
+
+    """
+
+    remove_user_memberships(user)
+    for group in group_profiles:
+        add_groups_to_user(
+            user, group_profile=group, group=group.group)
+
+
+def remove_user_memberships(user):
+    """Remove user from all ``GroupMember`` instances and django groups
+
+    """
+
+    existing_group_profile_memberships = GroupMember.objects.filter(
+        user=user).values_list("group__slug", flat=True)
+    user.groups.filter(name__in=existing_group_profile_memberships).delete()
+    GroupMember.objects.filter(user=user).delete()
+
+
+def add_groups_to_user(user, group_profile, group):
+    """Adds groups to a user.
+
+    This will add both a `django.contrib.auth.models.Group` and a also a
+    ``geonode.groups.models.GroupProfile``, by means of creating a
+    ``geonode.groups.models.GroupMember``.
+
+    """
+
+    user.groups.add(group)
+    GroupMember.objects.create(
+        user=user, group=group_profile, role=GroupMember.MEMBER)

--- a/ldap/geonode_ldap/config.py
+++ b/ldap/geonode_ldap/config.py
@@ -1,0 +1,17 @@
+from django.template.defaultfilters import slugify
+from django_auth_ldap import config
+
+
+class GeonodeNestedGroupOfNamesType(config.NestedGroupOfNamesType):
+    """Reimplemented in order to truncate group names to 50 characters
+
+    This is needed since geonode's ``groups.GroupProfile`` model mandates
+    that the group's ``title`` and ``slug`` fields be at most 50 chars.
+
+    """
+
+    def group_name_from_info(self, group_info):
+        name = super(GeonodeNestedGroupOfNamesType, self).group_name_from_info(
+            group_info)
+        safe_name = slugify(name)[:50]
+        return safe_name

--- a/ldap/geonode_ldap/settings.py
+++ b/ldap/geonode_ldap/settings.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+try:
+    LDAP_GROUP_PROFILE_FILTERSTR = settings.GEONODE_LDAP_GROUP_PROFILE_FILTERSTR
+except AttributeError:
+    raise ImproperlyConfigured(
+        "Please set the GEONODE_LDAP_GROUP_PROFILE_FILTERSTR variable")
+
+LDAP_GROUP_NAME_ATTRIBUTE = getattr(
+    settings,
+    "GEONODE_LDAP_GROUP_NAME_ATTRIBUTE",
+    "cn"
+)

--- a/ldap/geonode_ldap/utils.py
+++ b/ldap/geonode_ldap/utils.py
@@ -1,0 +1,74 @@
+"""Custom utilities for managing LDAP logins"""
+
+from django.template.defaultfilters import slugify
+
+from django_auth_ldap import backend
+import ldap
+
+from . import settings
+
+
+def get_ldap_groups_map(user=None):
+    """Return a dict with group_slug, group_name for each LDAP group
+
+    If ``user`` is provided, returns only the groups that the user is a member
+    of in LDAP.
+
+    """
+
+    ldap_backend = backend.LDAPBackend()
+    conn = ldap.initialize(ldap_backend.settings.SERVER_URI)
+    conn.simple_bind_s(
+        ldap_backend.settings.BIND_DN,
+        ldap_backend.settings.BIND_PASSWORD
+    )
+    if user:
+        filter_ = _get_ldap_groups_filter(user, ldap_backend)
+    else:
+        filter_ = "{}".format(settings.LDAP_GROUP_PROFILE_FILTERSTR)
+    remote_groups = conn.search_s(
+        base=ldap_backend.settings.GROUP_SEARCH.base_dn,
+        scope=ldap.SCOPE_SUBTREE,
+        filterstr=filter_
+    )
+    result = {}
+    for cn, attributes in remote_groups:
+        group_name = " ".join(
+            attributes[settings.LDAP_GROUP_NAME_ATTRIBUTE])
+        sanitized_name = sanitize_group_name(group_name)
+        result[slugify(sanitized_name)] = {
+            "original": group_name,
+            "sanitized": sanitized_name,
+        }
+    return result
+
+
+def sanitize_group_name(name):
+    """Return a name that is suitable for use when creating geonode groups
+
+    Geonode currently uses two group types:
+
+    * standard ``django.contrib.auth.models.Group``
+
+    * custom ``geonode.groups.models.GroupProfile`` - this model also manages
+      user memberships, through  the ``geonode.groups.models.GroupMember``
+      class. These memberships are used for the UI, but they are not used for
+      enforcing permissions - the standard ``Group`` and its relation to the
+      user model is used for that
+
+    Geonode ``GroupProfile`` titles and slugs are restricted to 50 chars
+    and the ``Group`` names are set from the ``GroupProfile.slug``
+
+    """
+
+    sanitized_name = name[:50]
+    return sanitized_name
+
+
+def _get_ldap_groups_filter(user, ldap_backend):
+    if not hasattr(user, "ldap_user"):
+        user = ldap_backend.populate_user(user.username)
+    return "(&{}(member={}))".format(
+        settings.LDAP_GROUP_PROFILE_FILTERSTR,
+        user.ldap_user.dn
+    )

--- a/ldap/setup.py
+++ b/ldap/setup.py
@@ -1,0 +1,36 @@
+import io
+from os.path import (
+    dirname,
+    join,
+)
+from setuptools import (
+    find_packages,
+    setup
+)
+
+
+def read(*names, **kwargs):
+    return io.open(
+        join(dirname(__file__), *names),
+        encoding=kwargs.get("encoding", "utf-8")
+    ).read()
+
+
+setup(
+    name="geonode_ldap",
+    version="1.0.0",
+    description="GeoNode contrib app for integrating with django_auth_ldap",
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    author="Ricardo Garcia Silva",
+    author_email="ricardo.garcia.silva@gmail.com",
+    url="https://github.com/GeoNode/geonode-contribs",
+    license="GPL",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        "django-auth-ldap",
+        "geonode",
+        "python-ldap",
+    ],
+)


### PR DESCRIPTION
This PR adds a new `LDAP` contrib package that eases the integration of [django_auth_ldap][1] with geonode. It includes installation instructions and example config in the `README.md` file

#### NOTE
This PR is following the structure proposed in #1, i.e the `ldap` contrib package:

-  has its own `setup.py` file, and therefore can be installed independently from other geonode contrib packages
-  is located in `geonode_contribs/ldap`, without extra nesting


[1]: https://django-auth-ldap.readthedocs.io/en/latest/index.html