### PR TITLE
GEONODE_LDAP_GROUP_PROFILE_FILTERSTR now has a default value

### DIFF
--- a/ldap/geonode_ldap/settings.py
+++ b/ldap/geonode_ldap/settings.py
@@ -1,12 +1,11 @@
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 
 
-try:
-    LDAP_GROUP_PROFILE_FILTERSTR = settings.GEONODE_LDAP_GROUP_PROFILE_FILTERSTR
-except AttributeError:
-    raise ImproperlyConfigured(
-        "Please set the GEONODE_LDAP_GROUP_PROFILE_FILTERSTR variable")
+LDAP_GROUP_PROFILE_FILTERSTR = getattr(
+    settings,
+    "GEONODE_LDAP_GROUP_PROFILE_FILTERSTR",
+    "(objectClass=*)"
+)
 
 LDAP_GROUP_NAME_ATTRIBUTE = getattr(
     settings,


### PR DESCRIPTION
This PR makes the `GEONODE_LDAP_GROUP_PROFILE_FILTERSTR` setting become optional. The default value is the same as the one provided by the underlying [python_ldap package](https://github.com/python-ldap/python-ldap/blob/1d373da3746842b4c09f933896f3b37c4b36cd88/Lib/ldap/ldapobject.py#L836)

closes #4 
