### PR TITLE
[FIXES #132] mirror group function is used, even though MIRROR_GROUPS is false 

### DIFF
--- a/ldap/geonode_ldap/backend.py
+++ b/ldap/geonode_ldap/backend.py
@@ -179,7 +179,7 @@ class GeonodeLdapBackend(backend.LDAPBackend):
             ldap_user._user.keywords.add("ldap")
 
         # This has to wait until we're sure the user has a pk.
-        if self.settings.MIRROR_GROUPS or self.settings.MIRROR_GROUPS_EXCEPT:
+        if self.settings.MIRROR_GROUPS and self.settings.MIRROR_GROUPS_EXCEPT:
             ldap_user._normalize_mirror_settings()
             self._mirror_groups(ldap_user)
 


### PR DESCRIPTION
In conjunction with: https://github.com/GeoNode/documentation/pull/63