### PR TITLE
Fix: The app label 'keycloak-role' is not a valid Python identifier.

### DIFF
--- a/django-geonode-keycloak/README.md
+++ b/django-geonode-keycloak/README.md
@@ -31,11 +31,6 @@ When creating your public client:
 5. Add the following web origin: *
 ### **Inside your web-app**
 The following files required to be modified before configuration of geonode:
-### **> requirements.txt**
-Add the following installment to the file
-```bash
-git+ssh://git@gitlab.catalyst.net.nz/giscore/django-geonode-keycloak.git@master
-```
 
 #### **> settings.py**
 Add the app to INSTALLED_APPS above 'geonode'

--- a/django-geonode-keycloak/keycloakrole/apps.py
+++ b/django-geonode-keycloak/keycloakrole/apps.py
@@ -3,5 +3,5 @@ from django.apps import AppConfig
 
 class KeycloakConfig(AppConfig):
     name = 'keycloakrole'
-    label = 'keycloak-role'
+    label = 'keycloakrole'
     verbose_name = 'Keycloak'  # Sets the display name within django administration.


### PR DESCRIPTION
This is a fix for #138