### PR TITLE
Use Keycloak realm consistently in requests

### DIFF
--- a/django-geonode-keycloak/keycloakrole/helper.py
+++ b/django-geonode-keycloak/keycloakrole/helper.py
@@ -9,7 +9,7 @@ BASE_URL = settings.KEYCLOAK_HOST_URL
 # It then creates a post request.
 # Returns the access token.
 def get_token():
-    url = f'{BASE_URL}/auth/realms/master/protocol/openid-connect/token'
+    url = f'{BASE_URL}/auth/realms/{settings.KEYCLOAK_REALM}/protocol/openid-connect/token'
     data = {
         'client_id': settings.KEYCLOAK_CLIENT,
         'client_secret': settings.KEYCLOAK_CLIENT_SECRET,

--- a/django-geonode-keycloak/keycloakrole/tests.py
+++ b/django-geonode-keycloak/keycloakrole/tests.py
@@ -49,7 +49,7 @@ class KeycloakRequestMockTest(TestCase):
 
     def test_post_call(self):
         BASE_URL = settings.KEYCLOAK_HOST_URL
-        url = f'{BASE_URL}/auth/realms/master/protocol/openid-connect/token'
+        url = f'{BASE_URL}/auth/realms/{settings.KEYCLOAK_REALM}/protocol/openid-connect/token'
         data = {
             'client_id': settings.KEYCLOAK_CLIENT,
             'client_secret': settings.KEYCLOAK_CLIENT_SECRET,


### PR DESCRIPTION
The configured realm should be used when generating an access token, as
well as when getting keycloak roles.