### PR TITLE
Update ldaps setup.py to use geonode 3.x as dependency

### DIFF
--- a/ldap/setup.py
+++ b/ldap/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "django-auth-ldap",
-        "geonode",
+        "geonode<=4.0",
         "python-ldap",
     ],
 )


### PR DESCRIPTION
My 3.2.x Stack wouldn't start because geonode-contribs/ldap would link to geonode 4.0 as a dependency. Therefore i needed to fork and ask you to add a 3.2.x branch with my tiny change, so others might profit from this fix to a not yet filed issue.

But obviously it should not link into master, but into a new 3.2.x branch. Could you add it so I could base this pull request onto that?