### PR TITLE
add support for group descriptions served as string

### DIFF
--- a/ldap/geonode_ldap/management/commands/updateldapgroups.py
+++ b/ldap/geonode_ldap/management/commands/updateldapgroups.py
@@ -98,7 +98,10 @@ class Command(BaseCommand):
             group_name = b" ".join(
                 attributes[group_name_attribute]).decode("utf-8")
             # group_name = slugify(" ".join(attributes[group_name_attribute]))
-            description = b" ".join(
+            if (isinstance(attributes.get("description", group_name), str)):
+              description = " ".join(attributes.get("description", group_name))
+            else:
+              description = b" ".join(
                 attributes.get("description", group_name)).decode("utf-8")
             truncated_name = group_name[:50]
             if truncated_name != group_name:


### PR DESCRIPTION
I have set up an Active Directory connection, and some group descriptions are served as string type while others are served as byte-array type. This change adds support for the string type too.