### PR TITLE
Update django-auth-ldap for geonode 4.3

### DIFF
--- a/ldap/setup.py
+++ b/ldap/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "django-auth-ldap==4.1.0",
+        "django-auth-ldap~=4.8",
         "python-ldap",
     ],
 )


### PR DESCRIPTION
@giohappy 

This is version bump of django-auth-ldap is needed for the planned 4.3 release.
Could not find any other problems than that in my tests